### PR TITLE
Add button to inject PBIX JSON into chat

### DIFF
--- a/ChatGPT-4.1 API/ChatGPT_4.1_API.py
+++ b/ChatGPT-4.1 API/ChatGPT_4.1_API.py
@@ -1,6 +1,8 @@
 import os
 import json
 import subprocess
+import io
+import zipfile
 import streamlit as st
 from openai import OpenAI
 
@@ -40,6 +42,30 @@ TOOLS = [
     }
 ]
 
+# --- Power BI Processing ---
+def process_pbix(pbix_bytes: bytes) -> dict:
+    """Extract key JSON files from a PBIX archive."""
+    result = {}
+    try:
+        with zipfile.ZipFile(io.BytesIO(pbix_bytes)) as zf:
+            for name in zf.namelist():
+                lower = name.lower()
+                if lower.endswith("datamodelschema"):
+                    result["DataModelSchema"] = json.loads(
+                        zf.read(name).decode("utf-8", errors="ignore")
+                    )
+                elif lower.endswith("metadata"):
+                    result["Metadata"] = json.loads(
+                        zf.read(name).decode("utf-8", errors="ignore")
+                    )
+                elif lower.endswith("report/layout") or lower.endswith("layout"):
+                    result["Layout"] = json.loads(
+                        zf.read(name).decode("utf-8", errors="ignore")
+                    )
+    except Exception as e:
+        result["error"] = str(e)
+    return result
+
 # --- API KEY SETUP ---
 API_KEY = os.environ.get("OPENAI_API_KEY")
 if not API_KEY:
@@ -64,6 +90,10 @@ st.sidebar.markdown(
     - [GitHub](https://github.com/openai/openai-python)
     """
 )
+
+# Set defaults
+temp = TEMPERATURE
+max_tokens = MAX_TOKENS
 
 if "computer_mode" not in st.session_state:
     st.session_state.computer_mode = False
@@ -120,6 +150,31 @@ st.markdown(
     </style>
     """, unsafe_allow_html=True
 )
+
+# --- Power BI Upload ---
+pbix_file = st.sidebar.file_uploader("Upload Power BI .pbix", type=["pbix"])
+if pbix_file:
+    with st.spinner("Processing PBIX..."):
+        pbix_data = process_pbix(pbix_file.getvalue())
+        st.session_state.pbix_json = json.dumps(pbix_data, indent=2)
+
+if "pbix_json" in st.session_state:
+    st.subheader("Extracted PBIX JSON")
+    st.download_button(
+        "Download JSON",
+        st.session_state.pbix_json,
+        file_name="pbix.json",
+        mime="application/json",
+    )
+    st.text_area("PBIX JSON Preview", st.session_state.pbix_json, height=300)
+    if st.button("Send PBIX JSON to ChatGPT"):
+        st.session_state.messages.append(
+            {
+                "role": "user",
+                "content": f"PBIX JSON:\n```json\n{st.session_state.pbix_json}\n```",
+            }
+        )
+        st.experimental_rerun()
 
 # Show conversation history
 for msg in st.session_state.messages[1:]:

--- a/ChatGPT_4.1_API.py
+++ b/ChatGPT_4.1_API.py
@@ -1,6 +1,8 @@
 import os
 import json
 import subprocess
+import io
+import zipfile
 import streamlit as st
 from openai import OpenAI
 
@@ -39,6 +41,30 @@ TOOLS = [
         },
     }
 ]
+
+# --- Power BI Processing ---
+def process_pbix(pbix_bytes: bytes) -> dict:
+    """Extract key JSON files from a PBIX archive."""
+    result = {}
+    try:
+        with zipfile.ZipFile(io.BytesIO(pbix_bytes)) as zf:
+            for name in zf.namelist():
+                lower = name.lower()
+                if lower.endswith("datamodelschema"):
+                    result["DataModelSchema"] = json.loads(
+                        zf.read(name).decode("utf-8", errors="ignore")
+                    )
+                elif lower.endswith("metadata"):
+                    result["Metadata"] = json.loads(
+                        zf.read(name).decode("utf-8", errors="ignore")
+                    )
+                elif lower.endswith("report/layout") or lower.endswith("layout"):
+                    result["Layout"] = json.loads(
+                        zf.read(name).decode("utf-8", errors="ignore")
+                    )
+    except Exception as e:
+        result["error"] = str(e)
+    return result
 
 # --- API KEY SETUP ---
 API_KEY = os.environ.get("OPENAI_API_KEY")
@@ -124,6 +150,31 @@ st.markdown(
     </style>
     """, unsafe_allow_html=True
 )
+
+# --- Power BI Upload ---
+pbix_file = st.sidebar.file_uploader("Upload Power BI .pbix", type=["pbix"])
+if pbix_file:
+    with st.spinner("Processing PBIX..."):
+        pbix_data = process_pbix(pbix_file.getvalue())
+        st.session_state.pbix_json = json.dumps(pbix_data, indent=2)
+
+if "pbix_json" in st.session_state:
+    st.subheader("Extracted PBIX JSON")
+    st.download_button(
+        "Download JSON",
+        st.session_state.pbix_json,
+        file_name="pbix.json",
+        mime="application/json",
+    )
+    st.text_area("PBIX JSON Preview", st.session_state.pbix_json, height=300)
+    if st.button("Send PBIX JSON to ChatGPT"):
+        st.session_state.messages.append(
+            {
+                "role": "user",
+                "content": f"PBIX JSON:\n```json\n{st.session_state.pbix_json}\n```",
+            }
+        )
+        st.experimental_rerun()
 
 # Show conversation history
 for msg in st.session_state.messages[1:]:

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 This project provides a simple Streamlit UI for interacting with the ChatGPT 4.1 model.
 
+The application also includes a utility for working with **Power BI** reports. Upload a `.pbix` file in the sidebar to extract the report's data model and layout as JSON. The extracted JSON can be downloaded, reviewed in the browser, or sent directly to ChatGPT for modification using the **Send PBIX JSON to ChatGPT** button.
+
 ## Computer Use Mode
 
 The interface now includes an optional **computer use** mode. When enabled in the


### PR DESCRIPTION
## Summary
- refine `process_pbix` to handle case-insensitive file paths
- add button to send uploaded Power BI data directly into the chat
- document the new chat button in the README

## Testing
- `python -m py_compile ChatGPT_4.1_API.py 'ChatGPT-4.1 API/ChatGPT_4.1_API.py'`

------
https://chatgpt.com/codex/tasks/task_e_6840d577b254832799b6f8de7f1d6c26