### PR TITLE
Add PBIX editing utilities

### DIFF
--- a/ChatGPT-4.1 API/ChatGPT_4.1_API.py
+++ b/ChatGPT-4.1 API/ChatGPT_4.1_API.py
@@ -5,6 +5,11 @@ import io
 import zipfile
 import streamlit as st
 from openai import OpenAI
+from pbix_utils import (
+    add_dax_measure as _add_dax_measure,
+    create_relationship as _create_relationship,
+    add_visual as _add_visual,
+)
 
 # --- SETTINGS ---
 MODEL = "gpt-4.1"  # 1M context as of 2024
@@ -42,6 +47,43 @@ def update_pbix_json(json_str: str) -> str:
     except Exception as e:
         return f"Error updating PBIX JSON: {e}"
 
+
+def add_dax_measure(table_name: str, measure_name: str, expression: str) -> str:
+    """Add or update a DAX measure in the loaded PBIX data."""
+    if "pbix_data" not in st.session_state:
+        return "No PBIX JSON loaded"
+    try:
+        _add_dax_measure(st.session_state.pbix_data, table_name, measure_name, expression)
+        st.session_state.pbix_json = json.dumps(st.session_state.pbix_data, indent=2)
+        return "DAX measure added"
+    except Exception as e:
+        return f"Error adding measure: {e}"
+
+
+def create_relationship(from_table: str, from_column: str, to_table: str, to_column: str) -> str:
+    """Create a relationship between two tables."""
+    if "pbix_data" not in st.session_state:
+        return "No PBIX JSON loaded"
+    try:
+        _create_relationship(st.session_state.pbix_data, from_table, from_column, to_table, to_column)
+        st.session_state.pbix_json = json.dumps(st.session_state.pbix_data, indent=2)
+        return "Relationship created"
+    except Exception as e:
+        return f"Error creating relationship: {e}"
+
+
+def add_visual(page_index: int, visual_json: str) -> str:
+    """Add a new visual to the specified page in the Layout."""
+    if "pbix_data" not in st.session_state:
+        return "No PBIX JSON loaded"
+    try:
+        visual = json.loads(visual_json)
+        _add_visual(st.session_state.pbix_data, page_index, visual)
+        st.session_state.pbix_json = json.dumps(st.session_state.pbix_data, indent=2)
+        return "Visual added"
+    except Exception as e:
+        return f"Error adding visual: {e}"
+
 TOOLS = [
     {
         "type": "function",
@@ -72,6 +114,54 @@ TOOLS = [
                 "type": "object",
                 "properties": {"json_str": {"type": "string", "description": "The complete PBIX JSON."}},
                 "required": ["json_str"],
+            },
+        },
+    },
+    {
+        "type": "function",
+        "function": {
+            "name": "add_dax_measure",
+            "description": "Add or update a DAX measure in the loaded PBIX file.",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "table_name": {"type": "string", "description": "Table to contain the measure"},
+                    "measure_name": {"type": "string", "description": "Name of the measure"},
+                    "expression": {"type": "string", "description": "DAX expression"},
+                },
+                "required": ["table_name", "measure_name", "expression"],
+            },
+        },
+    },
+    {
+        "type": "function",
+        "function": {
+            "name": "create_relationship",
+            "description": "Create a relationship between two tables in the PBIX model.",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "from_table": {"type": "string"},
+                    "from_column": {"type": "string"},
+                    "to_table": {"type": "string"},
+                    "to_column": {"type": "string"},
+                },
+                "required": ["from_table", "from_column", "to_table", "to_column"],
+            },
+        },
+    },
+    {
+        "type": "function",
+        "function": {
+            "name": "add_visual",
+            "description": "Add a new visual to a report page.",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "page_index": {"type": "integer", "description": "Zero-based page index"},
+                    "visual_json": {"type": "string", "description": "Visual definition as JSON"},
+                },
+                "required": ["page_index", "visual_json"],
             },
         },
     },
@@ -149,7 +239,7 @@ if "messages" not in st.session_state:
             "content": (
                 "You are ChatGPT, a helpful assistant with a 1 million token context window. "
                 "When computer use is enabled you may run shell commands using the `run_command` tool. "
-                "You can inspect or modify an uploaded Power BI report using the `get_pbix_json` and `update_pbix_json` tools."
+                "You can inspect or modify an uploaded Power BI report using the `get_pbix_json`, `update_pbix_json`, `add_dax_measure`, `create_relationship`, and `add_visual` tools."
             ),
         }
     ]
@@ -267,6 +357,48 @@ if user_input:
                                     "content": output,
                                 }
                             )
+                        elif call.function.name == "add_dax_measure":
+                            args = json.loads(call.function.arguments)
+                            output = add_dax_measure(
+                                args.get("table_name", ""),
+                                args.get("measure_name", ""),
+                                args.get("expression", ""),
+                            )
+                            st.session_state.messages.append(
+                                {
+                                    "role": "function",
+                                    "name": "add_dax_measure",
+                                    "content": output,
+                                }
+                            )
+                        elif call.function.name == "create_relationship":
+                            args = json.loads(call.function.arguments)
+                            output = create_relationship(
+                                args.get("from_table", ""),
+                                args.get("from_column", ""),
+                                args.get("to_table", ""),
+                                args.get("to_column", ""),
+                            )
+                            st.session_state.messages.append(
+                                {
+                                    "role": "function",
+                                    "name": "create_relationship",
+                                    "content": output,
+                                }
+                            )
+                        elif call.function.name == "add_visual":
+                            args = json.loads(call.function.arguments)
+                            output = add_visual(
+                                args.get("page_index", 0),
+                                args.get("visual_json", ""),
+                            )
+                            st.session_state.messages.append(
+                                {
+                                    "role": "function",
+                                    "name": "add_visual",
+                                    "content": output,
+                                }
+                            )
                     response = client.chat.completions.create(
                         model=MODEL,
                         messages=st.session_state.messages,
@@ -297,7 +429,7 @@ if st.sidebar.button("🧹 Clear chat history"):
             "content": (
                 "You are ChatGPT, a helpful assistant with a 1 million token context window. "
                 "When computer use is enabled you may run shell commands using the `run_command` tool. "
-                "You can inspect or modify an uploaded Power BI report using the `get_pbix_json` and `update_pbix_json` tools."
+                "You can inspect or modify an uploaded Power BI report using the `get_pbix_json`, `update_pbix_json`, `add_dax_measure`, `create_relationship`, and `add_visual` tools."
             ),
         }
     ]

--- a/ChatGPT_4.1_API.py
+++ b/ChatGPT_4.1_API.py
@@ -5,6 +5,11 @@ import io
 import zipfile
 import streamlit as st
 from openai import OpenAI
+from pbix_utils import (
+    add_dax_measure as _add_dax_measure,
+    create_relationship as _create_relationship,
+    add_visual as _add_visual,
+)
 
 # --- SETTINGS ---
 MODEL = "gpt-4.1"  # 1M context as of 2024
@@ -42,6 +47,43 @@ def update_pbix_json(json_str: str) -> str:
     except Exception as e:
         return f"Error updating PBIX JSON: {e}"
 
+
+def add_dax_measure(table_name: str, measure_name: str, expression: str) -> str:
+    """Add or update a DAX measure in the loaded PBIX data."""
+    if "pbix_data" not in st.session_state:
+        return "No PBIX JSON loaded"
+    try:
+        _add_dax_measure(st.session_state.pbix_data, table_name, measure_name, expression)
+        st.session_state.pbix_json = json.dumps(st.session_state.pbix_data, indent=2)
+        return "DAX measure added"
+    except Exception as e:
+        return f"Error adding measure: {e}"
+
+
+def create_relationship(from_table: str, from_column: str, to_table: str, to_column: str) -> str:
+    """Create a relationship between two tables."""
+    if "pbix_data" not in st.session_state:
+        return "No PBIX JSON loaded"
+    try:
+        _create_relationship(st.session_state.pbix_data, from_table, from_column, to_table, to_column)
+        st.session_state.pbix_json = json.dumps(st.session_state.pbix_data, indent=2)
+        return "Relationship created"
+    except Exception as e:
+        return f"Error creating relationship: {e}"
+
+
+def add_visual(page_index: int, visual_json: str) -> str:
+    """Add a new visual to the specified page in the Layout."""
+    if "pbix_data" not in st.session_state:
+        return "No PBIX JSON loaded"
+    try:
+        visual = json.loads(visual_json)
+        _add_visual(st.session_state.pbix_data, page_index, visual)
+        st.session_state.pbix_json = json.dumps(st.session_state.pbix_data, indent=2)
+        return "Visual added"
+    except Exception as e:
+        return f"Error adding visual: {e}"
+
 TOOLS = [
     {
         "type": "function",
@@ -72,6 +114,54 @@ TOOLS = [
                 "type": "object",
                 "properties": {"json_str": {"type": "string", "description": "The complete PBIX JSON."}},
                 "required": ["json_str"],
+            },
+        },
+    },
+    {
+        "type": "function",
+        "function": {
+            "name": "add_dax_measure",
+            "description": "Add or update a DAX measure in the loaded PBIX file.",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "table_name": {"type": "string", "description": "Table to contain the measure"},
+                    "measure_name": {"type": "string", "description": "Name of the measure"},
+                    "expression": {"type": "string", "description": "DAX expression"},
+                },
+                "required": ["table_name", "measure_name", "expression"],
+            },
+        },
+    },
+    {
+        "type": "function",
+        "function": {
+            "name": "create_relationship",
+            "description": "Create a relationship between two tables in the PBIX model.",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "from_table": {"type": "string"},
+                    "from_column": {"type": "string"},
+                    "to_table": {"type": "string"},
+                    "to_column": {"type": "string"},
+                },
+                "required": ["from_table", "from_column", "to_table", "to_column"],
+            },
+        },
+    },
+    {
+        "type": "function",
+        "function": {
+            "name": "add_visual",
+            "description": "Add a new visual to a report page.",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "page_index": {"type": "integer", "description": "Zero-based page index"},
+                    "visual_json": {"type": "string", "description": "Visual definition as JSON"},
+                },
+                "required": ["page_index", "visual_json"],
             },
         },
     },
@@ -149,7 +239,7 @@ if "messages" not in st.session_state:
             "content": (
                 "You are ChatGPT, a helpful assistant with a 1 million token context window. "
                 "When computer use is enabled you may run shell commands using the `run_command` tool. "
-                "You can inspect or modify an uploaded Power BI report using the `get_pbix_json` and `update_pbix_json` tools."
+                "You can inspect or modify an uploaded Power BI report using the `get_pbix_json`, `update_pbix_json`, `add_dax_measure`, `create_relationship`, and `add_visual` tools."
             ),
         }
     ]
@@ -267,6 +357,48 @@ if user_input:
                                     "content": output,
                                 }
                             )
+                        elif call.function.name == "add_dax_measure":
+                            args = json.loads(call.function.arguments)
+                            output = add_dax_measure(
+                                args.get("table_name", ""),
+                                args.get("measure_name", ""),
+                                args.get("expression", ""),
+                            )
+                            st.session_state.messages.append(
+                                {
+                                    "role": "function",
+                                    "name": "add_dax_measure",
+                                    "content": output,
+                                }
+                            )
+                        elif call.function.name == "create_relationship":
+                            args = json.loads(call.function.arguments)
+                            output = create_relationship(
+                                args.get("from_table", ""),
+                                args.get("from_column", ""),
+                                args.get("to_table", ""),
+                                args.get("to_column", ""),
+                            )
+                            st.session_state.messages.append(
+                                {
+                                    "role": "function",
+                                    "name": "create_relationship",
+                                    "content": output,
+                                }
+                            )
+                        elif call.function.name == "add_visual":
+                            args = json.loads(call.function.arguments)
+                            output = add_visual(
+                                args.get("page_index", 0),
+                                args.get("visual_json", ""),
+                            )
+                            st.session_state.messages.append(
+                                {
+                                    "role": "function",
+                                    "name": "add_visual",
+                                    "content": output,
+                                }
+                            )
                     response = client.chat.completions.create(
                         model=MODEL,
                         messages=st.session_state.messages,
@@ -297,7 +429,7 @@ if st.sidebar.button("🧹 Clear chat history"):
             "content": (
                 "You are ChatGPT, a helpful assistant with a 1 million token context window. "
                 "When computer use is enabled you may run shell commands using the `run_command` tool. "
-                "You can inspect or modify an uploaded Power BI report using the `get_pbix_json` and `update_pbix_json` tools."
+                "You can inspect or modify an uploaded Power BI report using the `get_pbix_json`, `update_pbix_json`, `add_dax_measure`, `create_relationship`, and `add_visual` tools."
             ),
         }
     ]

--- a/README.md
+++ b/README.md
@@ -16,10 +16,15 @@ of the current user.
 ## PBIX Editing Tools
 
 When a Power BI report is uploaded, ChatGPT can analyze or modify the extracted
-JSON by calling two tools:
+JSON by calling several tools:
 
 * `get_pbix_json` – returns the current PBIX JSON so the assistant can inspect
   it and answer questions about the report.
 * `update_pbix_json` – accepts a complete JSON string and replaces the stored
-  report data with the new version. The parsed data is saved in the session so
-  you can continue editing or download the updated JSON from the sidebar.
+  report data with the new version.
+* `add_dax_measure` – create or update a DAX measure in the `DataModelSchema`.
+* `create_relationship` – define a relationship between two tables.
+* `add_visual` – append a new visual definition to the `Layout` of the report.
+
+The parsed data is saved in the session so you can continue editing or
+download the updated JSON from the sidebar.

--- a/pbix_utils.py
+++ b/pbix_utils.py
@@ -1,0 +1,52 @@
+import json
+from typing import Dict, Any
+
+
+def add_dax_measure(data: Dict[str, Any], table_name: str, measure_name: str, expression: str) -> Dict[str, Any]:
+    """Add or update a DAX measure in the DataModelSchema."""
+    schema = data.setdefault("DataModelSchema", {})
+    model = schema.setdefault("model", {})
+    tables = model.setdefault("tables", [])
+    for table in tables:
+        if table.get("name") == table_name:
+            measures = table.setdefault("measures", [])
+            for m in measures:
+                if m.get("name") == measure_name:
+                    m["expression"] = expression
+                    return data
+            measures.append({"name": measure_name, "expression": expression})
+            return data
+    # Table not found - create simple table with the new measure
+    tables.append({
+        "name": table_name,
+        "columns": [],
+        "measures": [{"name": measure_name, "expression": expression}],
+    })
+    return data
+
+
+def create_relationship(data: Dict[str, Any], from_table: str, from_column: str, to_table: str, to_column: str) -> Dict[str, Any]:
+    """Create a simple relationship between two tables."""
+    schema = data.setdefault("DataModelSchema", {})
+    model = schema.setdefault("model", {})
+    relationships = model.setdefault("relationships", [])
+    relationships.append({
+        "fromTable": from_table,
+        "fromColumn": from_column,
+        "toTable": to_table,
+        "toColumn": to_column,
+        "crossFilteringBehavior": "bothDirections",
+    })
+    return data
+
+
+def add_visual(data: Dict[str, Any], page_index: int, visual: Dict[str, Any]) -> Dict[str, Any]:
+    """Append a new visual definition to a layout page."""
+    layout = data.setdefault("Layout", {})
+    sections = layout.setdefault("sections", [])
+    if page_index < 0 or page_index >= len(sections):
+        raise IndexError("Invalid page index")
+    page = sections[page_index]
+    containers = page.setdefault("visualContainers", [])
+    containers.append(visual)
+    return data


### PR DESCRIPTION
## Summary
- add `pbix_utils.py` module with helper functions for PBIX modifications
- expose new Streamlit tools `add_dax_measure`, `create_relationship`, and `add_visual`
- integrate tools into ChatGPT loop and update system prompts
- document new Power BI editing tools in README

## Testing
- `python -m py_compile ChatGPT_4.1_API.py 'ChatGPT-4.1 API/ChatGPT_4.1_API.py' pbix_utils.py`

------
https://chatgpt.com/codex/tasks/task_e_6840dcbc6c888327bbf74b679a72c66e