### PR TITLE
Add PBIX utils and tests

### DIFF
--- a/pbix_utils.py
+++ b/pbix_utils.py
@@ -1,0 +1,40 @@
+import io
+import json
+import zipfile
+
+
+def process_pbix(pbix_bytes: bytes) -> dict:
+    """Extract key JSON files from a PBIX archive."""
+    result = {}
+    try:
+        with zipfile.ZipFile(io.BytesIO(pbix_bytes)) as zf:
+            for name in zf.namelist():
+                lower = name.lower()
+                if lower.endswith("datamodelschema"):
+                    result["DataModelSchema"] = json.loads(
+                        zf.read(name).decode("utf-8", errors="ignore")
+                    )
+                elif lower.endswith("metadata"):
+                    result["Metadata"] = json.loads(
+                        zf.read(name).decode("utf-8", errors="ignore")
+                    )
+                elif lower.endswith("report/layout") or lower.endswith("layout"):
+                    result["Layout"] = json.loads(
+                        zf.read(name).decode("utf-8", errors="ignore")
+                    )
+    except Exception as e:
+        result["error"] = str(e)
+    return result
+
+
+def package_pbix(data: dict) -> bytes:
+    """Create a PBIX archive from a data dictionary."""
+    bio = io.BytesIO()
+    with zipfile.ZipFile(bio, "w") as zf:
+        if "DataModelSchema" in data:
+            zf.writestr("DataModelSchema", json.dumps(data["DataModelSchema"]))
+        if "Metadata" in data:
+            zf.writestr("Metadata", json.dumps(data["Metadata"]))
+        if "Layout" in data:
+            zf.writestr("Report/Layout", json.dumps(data["Layout"]))
+    return bio.getvalue()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 openai>=1.0.0
 streamlit
+pytest

--- a/tests/test_pbix_utils.py
+++ b/tests/test_pbix_utils.py
@@ -1,0 +1,38 @@
+import os
+import sys
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+import io
+import zipfile
+
+from pbix_utils import process_pbix, package_pbix
+
+sample_data = {
+    "DataModelSchema": {"name": "model"},
+    "Metadata": {"id": 1},
+    "Layout": {"sections": []},
+}
+
+
+def create_sample_pbix_bytes():
+    """Create a sample pbix file bytes for testing."""
+    return package_pbix(sample_data)
+
+
+def test_process_pbix_extracts_components():
+    pbix_bytes = create_sample_pbix_bytes()
+    extracted = process_pbix(pbix_bytes)
+    assert extracted["DataModelSchema"] == sample_data["DataModelSchema"]
+    assert extracted["Metadata"] == sample_data["Metadata"]
+    assert extracted["Layout"] == sample_data["Layout"]
+
+
+def test_package_pbix_creates_valid_archive():
+    pbix_bytes = package_pbix(sample_data)
+    with zipfile.ZipFile(io.BytesIO(pbix_bytes)) as zf:
+        names = set(zf.namelist())
+    assert "DataModelSchema" in names
+    assert "Metadata" in names
+    assert "Report/Layout" in names
+    round_trip = process_pbix(pbix_bytes)
+    assert round_trip == sample_data


### PR DESCRIPTION
## Summary
- add pytest to the requirements
- implement `package_pbix` helper and expose `process_pbix`
- add regression tests for PBIX processing and packaging

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6840dcc1ad9483278b977f4a2795795c