### PR TITLE
Add Power BI editing and query tools

### DIFF
--- a/ChatGPT_4.1_API.py
+++ b/ChatGPT_4.1_API.py
@@ -9,6 +9,12 @@ from pbix_utils import (
     add_dax_measure as _add_dax_measure,
     create_relationship as _create_relationship,
     add_visual as _add_visual,
+    update_power_query as _update_power_query,
+    add_data_source as _add_data_source,
+    set_parameter as _set_parameter,
+    set_refresh_policy as _set_refresh_policy,
+    preview_table as _preview_table,
+    run_dax_query as _run_dax_query,
 )
 
 # --- SETTINGS ---
@@ -83,6 +89,77 @@ def add_visual(page_index: int, visual_json: str) -> str:
         return "Visual added"
     except Exception as e:
         return f"Error adding visual: {e}"
+
+
+def update_power_query(query_name: str, script: str) -> str:
+    """Add or update an M script in the loaded PBIX metadata."""
+    if "pbix_data" not in st.session_state:
+        return "No PBIX JSON loaded"
+    try:
+        _update_power_query(st.session_state.pbix_data, query_name, script)
+        st.session_state.pbix_json = json.dumps(st.session_state.pbix_data, indent=2)
+        return "Power Query updated"
+    except Exception as e:
+        return f"Error updating query: {e}"
+
+
+def add_data_source(source_json: str) -> str:
+    """Append a new data source definition."""
+    if "pbix_data" not in st.session_state:
+        return "No PBIX JSON loaded"
+    try:
+        source = json.loads(source_json)
+        _add_data_source(st.session_state.pbix_data, source)
+        st.session_state.pbix_json = json.dumps(st.session_state.pbix_data, indent=2)
+        return "Data source added"
+    except Exception as e:
+        return f"Error adding data source: {e}"
+
+
+def set_parameter(name: str, value: str) -> str:
+    """Create or update a parameter value."""
+    if "pbix_data" not in st.session_state:
+        return "No PBIX JSON loaded"
+    try:
+        _set_parameter(st.session_state.pbix_data, name, value)
+        st.session_state.pbix_json = json.dumps(st.session_state.pbix_data, indent=2)
+        return "Parameter set"
+    except Exception as e:
+        return f"Error setting parameter: {e}"
+
+
+def set_refresh_policy(policy_json: str) -> str:
+    """Update refresh policy information."""
+    if "pbix_data" not in st.session_state:
+        return "No PBIX JSON loaded"
+    try:
+        policy = json.loads(policy_json)
+        _set_refresh_policy(st.session_state.pbix_data, policy)
+        st.session_state.pbix_json = json.dumps(st.session_state.pbix_data, indent=2)
+        return "Refresh policy updated"
+    except Exception as e:
+        return f"Error setting refresh policy: {e}"
+
+
+def preview_table(table_name: str, max_rows: int = 5) -> str:
+    """Return a preview of a table's rows as JSON."""
+    if "pbix_data" not in st.session_state:
+        return "No PBIX JSON loaded"
+    rows = _preview_table(st.session_state.pbix_data, table_name, max_rows)
+    return json.dumps(rows, indent=2)
+
+
+def run_dax_query(expression: str) -> str:
+    """Execute a very small subset of DAX queries for debugging."""
+    if "pbix_data" not in st.session_state:
+        return "No PBIX JSON loaded"
+    try:
+        result = _run_dax_query(st.session_state.pbix_data, expression)
+        if isinstance(result, (dict, list)):
+            return json.dumps(result, indent=2)
+        return str(result)
+    except Exception as e:
+        return f"Error running query: {e}"
 
 TOOLS = [
     {
@@ -162,6 +239,91 @@ TOOLS = [
                     "visual_json": {"type": "string", "description": "Visual definition as JSON"},
                 },
                 "required": ["page_index", "visual_json"],
+            },
+        },
+    },
+    {
+        "type": "function",
+        "function": {
+            "name": "update_power_query",
+            "description": "Create or update an M script in the report metadata.",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "query_name": {"type": "string"},
+                    "script": {"type": "string"},
+                },
+                "required": ["query_name", "script"],
+            },
+        },
+    },
+    {
+        "type": "function",
+        "function": {
+            "name": "add_data_source",
+            "description": "Add a new data source definition to the PBIX metadata.",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "source_json": {"type": "string", "description": "Data source definition as JSON"},
+                },
+                "required": ["source_json"],
+            },
+        },
+    },
+    {
+        "type": "function",
+        "function": {
+            "name": "set_parameter",
+            "description": "Set or update a parameter value in the PBIX metadata.",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "name": {"type": "string"},
+                    "value": {"type": "string"},
+                },
+                "required": ["name", "value"],
+            },
+        },
+    },
+    {
+        "type": "function",
+        "function": {
+            "name": "set_refresh_policy",
+            "description": "Update refresh policy details in the PBIX metadata.",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "policy_json": {"type": "string", "description": "Policy definition as JSON"},
+                },
+                "required": ["policy_json"],
+            },
+        },
+    },
+    {
+        "type": "function",
+        "function": {
+            "name": "preview_table",
+            "description": "Return sample rows from a model table.",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "table_name": {"type": "string"},
+                    "max_rows": {"type": "integer", "default": 5},
+                },
+                "required": ["table_name"],
+            },
+        },
+    },
+    {
+        "type": "function",
+        "function": {
+            "name": "run_dax_query",
+            "description": "Execute a limited DAX query for debugging.",
+            "parameters": {
+                "type": "object",
+                "properties": {"expression": {"type": "string"}},
+                "required": ["expression"],
             },
         },
     },
@@ -256,7 +418,7 @@ if "messages" not in st.session_state:
             "content": (
                 "You are ChatGPT, a helpful assistant with a 1 million token context window. "
                 "When computer use is enabled you may run shell commands using the `run_command` tool. "
-                "You can inspect or modify an uploaded Power BI report using the `get_pbix_json`, `update_pbix_json`, `add_dax_measure`, `create_relationship`, and `add_visual` tools."
+                "You can inspect or modify an uploaded Power BI report using the `get_pbix_json`, `update_pbix_json`, `add_dax_measure`, `create_relationship`, `add_visual`, `update_power_query`, `add_data_source`, `set_parameter`, `set_refresh_policy`, `preview_table`, and `run_dax_query` tools."
             ),
         }
     ]
@@ -458,7 +620,7 @@ if st.sidebar.button("🧹 Clear chat history"):
             "content": (
                 "You are ChatGPT, a helpful assistant with a 1 million token context window. "
                 "When computer use is enabled you may run shell commands using the `run_command` tool. "
-                "You can inspect or modify an uploaded Power BI report using the `get_pbix_json`, `update_pbix_json`, `add_dax_measure`, `create_relationship`, and `add_visual` tools."
+                "You can inspect or modify an uploaded Power BI report using the `get_pbix_json`, `update_pbix_json`, `add_dax_measure`, `create_relationship`, `add_visual`, `update_power_query`, `add_data_source`, `set_parameter`, `set_refresh_policy`, `preview_table`, and `run_dax_query` tools."
             ),
         }
     ]

--- a/README.md
+++ b/README.md
@@ -25,6 +25,12 @@ JSON by calling several tools:
 * `add_dax_measure` – create or update a DAX measure in the `DataModelSchema`.
 * `create_relationship` – define a relationship between two tables.
 * `add_visual` – append a new visual definition to the `Layout` of the report.
+* `update_power_query` – modify or add a Power Query (M) script in the report metadata.
+* `add_data_source` – register a new data source definition.
+* `set_parameter` – create or update a query parameter value.
+* `set_refresh_policy` – configure refresh policy details.
+* `preview_table` – return sample rows from a table for inspection.
+* `run_dax_query` – run a limited DAX query for debugging purposes.
 
 The parsed data is saved in the session so you can continue editing or
 download the updated JSON from the sidebar.

--- a/pbix_utils.py
+++ b/pbix_utils.py
@@ -88,3 +88,66 @@ def add_visual(data: Dict[str, Any], page_index: int, visual: Dict[str, Any]) ->
     containers = page.setdefault("visualContainers", [])
     containers.append(visual)
     return data
+
+
+def update_power_query(data: Dict[str, Any], query_name: str, script: str) -> Dict[str, Any]:
+    """Add or update an M script in the Metadata section."""
+    metadata = data.setdefault("Metadata", {})
+    queries = metadata.setdefault("queries", [])
+    for q in queries:
+        if q.get("name") == query_name:
+            q["expression"] = script
+            return data
+    queries.append({"name": query_name, "expression": script})
+    return data
+
+
+def add_data_source(data: Dict[str, Any], source: Dict[str, Any]) -> Dict[str, Any]:
+    """Append a new data source definition to Metadata."""
+    metadata = data.setdefault("Metadata", {})
+    sources = metadata.setdefault("dataSources", [])
+    sources.append(source)
+    return data
+
+
+def set_parameter(data: Dict[str, Any], param_name: str, value: Any) -> Dict[str, Any]:
+    """Create or update a parameter value in Metadata."""
+    metadata = data.setdefault("Metadata", {})
+    parameters = metadata.setdefault("parameters", [])
+    for p in parameters:
+        if p.get("name") == param_name:
+            p["currentValue"] = value
+            return data
+    parameters.append({"name": param_name, "currentValue": value})
+    return data
+
+
+def set_refresh_policy(data: Dict[str, Any], policy: Dict[str, Any]) -> Dict[str, Any]:
+    """Set refresh policy details inside Metadata."""
+    metadata = data.setdefault("Metadata", {})
+    metadata["refreshPolicy"] = policy
+    return data
+
+
+def preview_table(data: Dict[str, Any], table_name: str, max_rows: int = 5) -> Any:
+    """Return the first rows from a table if present."""
+    schema = data.get("DataModelSchema", {})
+    model = schema.get("model", {})
+    tables = model.get("tables", [])
+    for table in tables:
+        if table.get("name") == table_name:
+            rows = table.get("rows", [])
+            if max_rows is None:
+                return rows
+            return rows[:max_rows]
+    return []
+
+
+def run_dax_query(data: Dict[str, Any], expression: str) -> Any:
+    """Very small subset of DAX query capability for debugging."""
+    expr = expression.strip().upper()
+    if expr.startswith("ROWCOUNT(") and expr.endswith(")"):
+        table = expr[len("ROWCOUNT(") : -1].strip()
+        rows = preview_table(data, table, None)
+        return len(rows)
+    return "Query not supported"

--- a/tests/test_pbix_utils.py
+++ b/tests/test_pbix_utils.py
@@ -5,7 +5,16 @@ sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')
 import io
 import zipfile
 
-from pbix_utils import process_pbix, package_pbix
+from pbix_utils import (
+    process_pbix,
+    package_pbix,
+    update_power_query,
+    add_data_source,
+    set_parameter,
+    set_refresh_policy,
+    preview_table,
+    run_dax_query,
+)
 
 sample_data = {
     "DataModelSchema": {"name": "model"},
@@ -36,3 +45,40 @@ def test_package_pbix_creates_valid_archive():
     assert "Report/Layout" in names
     round_trip = process_pbix(pbix_bytes)
     assert round_trip == sample_data
+
+
+def test_update_power_query_adds_script():
+    data = {"Metadata": {"queries": []}}
+    update_power_query(data, "Query1", "let x = 1 in x")
+    assert data["Metadata"]["queries"][0]["name"] == "Query1"
+    assert data["Metadata"]["queries"][0]["expression"] == "let x = 1 in x"
+
+
+def test_add_data_source_appends_source():
+    data = {}
+    add_data_source(data, {"name": "src"})
+    assert data["Metadata"]["dataSources"][0]["name"] == "src"
+
+
+def test_set_parameter_updates_value():
+    data = {}
+    set_parameter(data, "Param", "Value")
+    assert data["Metadata"]["parameters"][0]["currentValue"] == "Value"
+
+
+def test_set_refresh_policy_stores_policy():
+    data = {}
+    set_refresh_policy(data, {"policy": "daily"})
+    assert data["Metadata"]["refreshPolicy"]["policy"] == "daily"
+
+
+def test_preview_table_and_run_dax_query():
+    data = {
+        "DataModelSchema": {
+            "model": {"tables": [{"name": "T", "rows": [{"a": 1}, {"a": 2}]}]}
+        }
+    }
+    rows = preview_table(data, "T", 1)
+    assert rows == [{"a": 1}]
+    count = run_dax_query(data, "ROWCOUNT(T)")
+    assert count == 2


### PR DESCRIPTION
## Summary
- add utilities for editing Power Query scripts and data sources
- expose new PBIX manipulation tools in the Streamlit UI
- provide table preview and simple DAX query execution
- document the additional functionality in README
- test new helper functions

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6841015697348327bfa3dd92e4e70793